### PR TITLE
E10s jsshell

### DIFF
--- a/config_build.sh
+++ b/config_build.sh
@@ -3,4 +3,4 @@
 APP_NAME=extensiondev
 CHROME_PROVIDERS="content locale skin"
 ROOT_FILES="install.js 7zip.bat cygzip.bat winrar.bat winzip.bat wzcline.bat zip.bat zip.sh"
-ROOT_DIRS="chrome"
+ROOT_DIRS="chrome modules"

--- a/content/chromeShellExtras.js
+++ b/content/chromeShellExtras.js
@@ -48,13 +48,30 @@ shellCommands.enumerateWindows = function enumerateWindows(search) {
 
     var n = 0;
     Shell.enumWins = [];
-    function printWindowLink (win) {
-        if (search && win.location.href.match(search) == null) {
+    function printScopeLink (obj) {
+        var isWindow = obj instanceof Window;
+        var url = isWindow ? obj.location.href : obj.currentURI.spec;
+        if (search && url.match(search) == null) {
             return; // doesn't match the specified search string.
         }
-        Shell.enumWins[n] = win;
-        printDoScope(win.location.href,'Shell.enumWins[' + n + ']');
+
+        if (isWindow) {
+            // Top-level window object
+            Shell.enumWins[n] = obj;
+        } else if (obj.isRemoteBrowser) {
+            // <xul:browser> object which will get special treatment
+            Shell.enumWins[n] = { __specialE10sScope__: obj };
+        } else {
+            // direct content window
+            Shell.enumWins[n] = obj.contentWindow;
+        }
+
+        var newdiv = printDoScope(url, 'Shell.enumWins[' + n + ']');
         n++;
+
+        if (!isWindow && obj.isRemoteBrowser) {
+            newdiv.classList.add("e10sScope");
+        }
     }
 
     while (en.hasMoreElements()) {
@@ -64,10 +81,10 @@ shellCommands.enumerateWindows = function enumerateWindows(search) {
             var ntabs = b.mPanelContainer.childNodes.length;
             for(var i=0; i<ntabs; i++) {
                 var tb = b.getBrowserAtIndex(i);
-                printWindowLink(tb.contentWindow);
+                printScopeLink(tb);
             }
         }
-        printWindowLink(w);
+        printScopeLink(w);
     }
 };
 

--- a/content/chromeShellExtras.js
+++ b/content/chromeShellExtras.js
@@ -1,5 +1,5 @@
-
 var RDFHistory = {}, Basics = {};
+var module = Components.utils['import'];
 module('resource://extensiondev/RDFHistory.js', RDFHistory);
 module('resource://extensiondev/BasicLanguageUtils.js', Basics);
 

--- a/content/shell.html
+++ b/content/shell.html
@@ -54,6 +54,43 @@ function init()
   refocus();
 }
 
+function runE10s(code) {
+  code = code.replace("'", "\\'", "g");
+  _scope.__specialE10sScope__.messageManager.loadFrameScript(
+    "data:,___lastRes___=null; \n" +
+    "try { println(eval('with(this){" + code + "}'), 'answer');\n" +
+    "} catch (e) { " +
+    "println(e, 'error');}", false, true);
+  setTimeout(Shell.refocus, 0);
+}
+
+function setUpE10sScopeForBrowser(browser) {
+  println("Scope is now an anonymous framescript for " + browser.currentURI.spec + ".", "message");
+  browser.messageManager.addMessageListener("_JSShell:Reply_", E10SListener);
+  browser.messageManager.loadFrameScript("data:,function println(s, type) { sendAsyncMessage('_JSShell:Reply_', {type: type, text: '' + s}); } function print(s) { println(s, 'print'); }", false, true);
+}
+
+var E10SListener = {
+  receiveMessage: function(msg) {
+    if (msg.target == _scope.__specialE10sScope__) {
+      switch (msg.data.type) {
+        case "print":
+          print(msg.data.text);
+          break;
+
+        case "answer":
+          if (msg.data.text != "undefined") {
+            printAnswer(msg.data.text);
+          }
+          break;
+
+        case "error":
+          println(msg.data.text, "error");
+      }
+    }
+  }
+};
+
 /**
  * Runs |code| in |_win|'s context.
  * @param overridenJSVer {int} (optional) overrides the default (specified by _jsVer)
@@ -324,6 +361,11 @@ scope : function scope(sc)
 {
   if (!sc) sc = {};
   _scope = sc;
+
+  if (sc.__specialE10sScope__) {
+    setUpE10sScopeForBrowser(sc.__specialE10sScope__);
+    return;
+  }
   println("Scope is now " + sc + ".  If a variable is not found in this scope, window will also be searched.  New variables will still go on window.", "message");
 },
 
@@ -724,6 +766,10 @@ function go(s)
   if (!("Shell" in _win))
     initTarget(); // silent
 
+  if (Shell._scope.__specialE10sScope__ && !/^scope\(|^enumerateWindows\(/.test(Shell.question)) {
+    runE10s(Shell.question);
+    return;
+  }
   // Evaluate Shell.question using _win's eval (this is why eval isn't in the |with|, IIRC).
   run(_win, "try{ Shell.printAnswer(eval('with(Shell._scope) with(Shell.shellCommands) {' + Shell.question + String.fromCharCode(10) + '}')); } catch(er) { Shell.printError(er); }; setTimeout(Shell.refocus, 0);");
 }
@@ -751,6 +797,8 @@ function go(s)
 
   .input { color: blue; background: white; font: inherit; font-weight: bold; margin-top: .5em; /* background: #E6E6FF; */ }
   .normalOutput { color: black; background: white; }
+  .e10sScope { font-style: italic; }
+  .e10sScope::after { content: " [remote]";}
   .print { color: brown; background: white; }
   .error { color: red; background: white; }
   .propList { color: green; background: white; }

--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>{75739dec-72db-4020-aa9a-6afa6744759b}</em:id>
     <em:name>Developer Assistant</em:name>
-    <em:version>0.3.0.20110927</em:version>
+    <em:version>0.3.0.20140917</em:version>
     <em:creator>Ted Mielczarek</em:creator>
     <em:contributor>Jesse Ruderman</em:contributor>
     <em:contributor>Cüneyt Yilmaz</em:contributor>
@@ -13,6 +13,7 @@
     <em:contributor>Cesar Oliveira</em:contributor>
     <em:contributor>Nickolay Ponomarev</em:contributor>
     <em:contributor>Brett Zamir</em:contributor>
+    <em:contributor>Felipe Gomes</em:contributor>
     <em:description>A suite of tools for developers</em:description>
     <em:iconURL>chrome://extensiondev/skin/extensiondev.png</em:iconURL>
     <em:homepageURL>http://ted.mielczarek.org/code/mozilla/extensiondev/</em:homepageURL>

--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>{75739dec-72db-4020-aa9a-6afa6744759b}</em:id>
     <em:name>Developer Assistant</em:name>
-    <em:version>0.3.0.20110827</em:version>
+    <em:version>0.3.0.20110927</em:version>
     <em:creator>Ted Mielczarek</em:creator>
     <em:contributor>Jesse Ruderman</em:contributor>
     <em:contributor>Cüneyt Yilmaz</em:contributor>


### PR DESCRIPTION
I imported r51 from google code which was missing here in the github repo. This also adds an experimental support in JS Shell for scoping it to remote tabs. It's not perfect (e.g. tabcomplete doesn't work), but it helps a lot with working with e10s.
